### PR TITLE
Fire Status effect + other minor fixes 

### DIFF
--- a/Assets/Materials/Lit/PUDDLE.mat
+++ b/Assets/Materials/Lit/PUDDLE.mat
@@ -1,0 +1,153 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PUDDLE
+  m_Shader: {fileID: -6465566751694194690, guid: d262ef4b7c10c7a0b90e0be9b7db0d2e, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 0
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _Base:
+        m_Texture: {fileID: 2800000, guid: 7b13ef7d454afb51991197bd714aefe2, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Layer1:
+        m_Texture: {fileID: 2800000, guid: 7b13ef7d454afb51991197bd714aefe2, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Texture2D:
+        m_Texture: {fileID: 10307, guid: 0000000000000000f000000000000000, type: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _DstBlendAlpha: 10
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0.23
+    - _Min_value_for_Dither: 0.3
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueControl: 0
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Scale: 1
+    - _Smoothness: 0.9
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 1
+    - _WorkflowMode: 1
+    - _XRMotionVectorsPass: 1
+    - _ZWrite: 0
+    - _dither_minimum_value: 0.2
+    m_Colors:
+    - _BaseColor: {r: 0.4641511, g: 0.11863652, b: 0.5849056, a: 0.7411765}
+    - _Color: {r: 0.990566, g: 0, b: 0.90086514, a: 0.7411765}
+    - _Direction: {r: 0.05, g: 0.01, b: 0, a: 0}
+    - _EmissionColor: {r: 0.11664047, g: 0.015218934, b: 0.16981131, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!114 &8931048850907165111
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Editor::UnityEditor.Rendering.Universal.AssetVersion
+  version: 10

--- a/Assets/Materials/Lit/PUDDLE.mat.meta
+++ b/Assets/Materials/Lit/PUDDLE.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dfe28104d0ab8f248a5d7fd8a7a6283c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Ingredients/BouncyModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/BouncyModifierIngredient.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 7048312572333856761}
   - component: {fileID: 1357258421107590579}
   - component: {fileID: 3325197152410463699}
+  - component: {fileID: 5063601947231819344}
   m_Layer: 8
   m_Name: BouncyModifierIngredient
   m_TagString: Untagged
@@ -184,8 +185,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -200,6 +199,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Ingredient
   ShowTopMostFoldoutHeaderGroup: 1
   _type: {fileID: 11400000, guid: 202dd6c2f11c07548bee79f002a411a7, type: 2}
+--- !u!114 &5063601947231819344
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9196376099781582157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1
 --- !u!1001 &377110538084843765
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/BouncyModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/BouncyModifierIngredient.prefab
@@ -185,6 +185,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Spring Lily
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/CloudBaseIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/CloudBaseIngredient.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 7048312572333856761}
   - component: {fileID: 1357258421107590579}
   - component: {fileID: 3325197152410463699}
+  - component: {fileID: 6592140786548872778}
   m_Layer: 8
   m_Name: CloudBaseIngredient
   m_TagString: Untagged
@@ -184,8 +185,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -200,6 +199,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Ingredient
   ShowTopMostFoldoutHeaderGroup: 1
   _type: {fileID: 11400000, guid: 54ce96e91901c1148bc26a521a529551, type: 2}
+--- !u!114 &6592140786548872778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9196376099781582157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1
 --- !u!1001 &7911499434432059882
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/CloudBaseIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/CloudBaseIngredient.prefab
@@ -185,6 +185,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Gaseous Grapes
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/CubeBaseIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/CubeBaseIngredient.prefab
@@ -106,6 +106,7 @@ GameObject:
   - component: {fileID: 7048312572333856761}
   - component: {fileID: 1357258421107590579}
   - component: {fileID: 3325197152410463699}
+  - component: {fileID: -2695761753538716755}
   m_Layer: 8
   m_Name: CubeBaseIngredient
   m_TagString: Untagged
@@ -189,7 +190,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.Netcode.Runtime::Unity.Netcode.NetworkObject
-  GlobalObjectIdHash: 1506310633
+  GlobalObjectIdHash: 1095959551
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
@@ -274,8 +275,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,3 +289,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Ingredient
   ShowTopMostFoldoutHeaderGroup: 1
   _type: {fileID: 11400000, guid: df67139eb25fb084892019b756b292a6, type: 2}
+--- !u!114 &-2695761753538716755
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9196376099781582157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1

--- a/Assets/Prefabs/Ingredients/CubeBaseIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/CubeBaseIngredient.prefab
@@ -275,6 +275,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Cuboid Crystal
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/FireModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/FireModifierIngredient.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 7048312572333856761}
   - component: {fileID: 1357258421107590579}
   - component: {fileID: 3325197152410463699}
+  - component: {fileID: 7351403624365304579}
   m_Layer: 8
   m_Name: FireModifierIngredient
   m_TagString: Untagged
@@ -184,8 +185,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -200,6 +199,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Ingredient
   ShowTopMostFoldoutHeaderGroup: 1
   _type: {fileID: 11400000, guid: acb4c96d71b7a8c46999566cc9ccb07e, type: 2}
+--- !u!114 &7351403624365304579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9196376099781582157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1
 --- !u!1001 &7801770025966716428
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/FireModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/FireModifierIngredient.prefab
@@ -185,6 +185,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Fiery Flower
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/FloatModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/FloatModifierIngredient.prefab
@@ -275,6 +275,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Floaty Ingredient
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/FloatModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/FloatModifierIngredient.prefab
@@ -106,6 +106,7 @@ GameObject:
   - component: {fileID: 7048312572333856761}
   - component: {fileID: 1357258421107590579}
   - component: {fileID: 3325197152410463699}
+  - component: {fileID: -3700512120372636442}
   m_Layer: 8
   m_Name: FloatModifierIngredient
   m_TagString: Untagged
@@ -274,8 +275,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,3 +289,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Ingredient
   ShowTopMostFoldoutHeaderGroup: 1
   _type: {fileID: 11400000, guid: 7f46b55ed2c91aa46aa20558cf64d660, type: 2}
+--- !u!114 &-3700512120372636442
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9196376099781582157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1

--- a/Assets/Prefabs/Ingredients/MagneticModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/MagneticModifierIngredient.prefab
@@ -275,6 +275,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Magnetic Ingredient
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/MagneticModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/MagneticModifierIngredient.prefab
@@ -106,6 +106,7 @@ GameObject:
   - component: {fileID: 7048312572333856761}
   - component: {fileID: 1357258421107590579}
   - component: {fileID: 3325197152410463699}
+  - component: {fileID: -1324246874669309126}
   m_Layer: 8
   m_Name: MagneticModifierIngredient
   m_TagString: Untagged
@@ -274,8 +275,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,3 +289,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Ingredient
   ShowTopMostFoldoutHeaderGroup: 1
   _type: {fileID: 11400000, guid: abe81566285932049921492618251f1e, type: 2}
+--- !u!114 &-1324246874669309126
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9196376099781582157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1

--- a/Assets/Prefabs/Ingredients/PuddleBaseIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/PuddleBaseIngredient.prefab
@@ -275,6 +275,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Puddle Ingredient
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/PuddleBaseIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/PuddleBaseIngredient.prefab
@@ -106,6 +106,7 @@ GameObject:
   - component: {fileID: 7048312572333856761}
   - component: {fileID: 1357258421107590579}
   - component: {fileID: 3325197152410463699}
+  - component: {fileID: 6879829441870621265}
   m_Layer: 8
   m_Name: PuddleBaseIngredient
   m_TagString: Untagged
@@ -274,8 +275,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,3 +289,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Ingredient
   ShowTopMostFoldoutHeaderGroup: 1
   _type: {fileID: 11400000, guid: 8f140ee81e995794e95f7982f6bd6a31, type: 2}
+--- !u!114 &6879829441870621265
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9196376099781582157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1

--- a/Assets/Prefabs/Ingredients/SizeModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/SizeModifierIngredient.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 7048312572333856761}
   - component: {fileID: 1357258421107590579}
   - component: {fileID: 3325197152410463699}
+  - component: {fileID: 6142377213520964652}
   m_Layer: 8
   m_Name: SizeModifierIngredient
   m_TagString: Untagged
@@ -184,8 +185,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -200,6 +199,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Ingredient
   ShowTopMostFoldoutHeaderGroup: 1
   _type: {fileID: 11400000, guid: 2edd4f2555f7d9e459d52bb97727380a, type: 2}
+--- !u!114 &6142377213520964652
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9196376099781582157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1
 --- !u!1001 &3343216561318285031
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/SizeModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/SizeModifierIngredient.prefab
@@ -185,6 +185,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Formidable Fungus
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Ingredients/SparkleModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/SparkleModifierIngredient.prefab
@@ -106,6 +106,7 @@ GameObject:
   - component: {fileID: 1357258421107590579}
   - component: {fileID: 3325197152410463699}
   - component: {fileID: 2188876764960685532}
+  - component: {fileID: 6715460303300944541}
   m_Layer: 8
   m_Name: SparkleModifierIngredient
   m_TagString: Untagged
@@ -253,8 +254,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,3 +289,16 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1.9025779, z: 1}
   m_Center: {x: 0, y: -0.45128894, z: 0}
+--- !u!114 &6715460303300944541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9196376099781582157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1

--- a/Assets/Prefabs/Ingredients/SparkleModifierIngredient.prefab
+++ b/Assets/Prefabs/Ingredients/SparkleModifierIngredient.prefab
@@ -254,6 +254,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Sparkle Seed
 --- !u!114 &3325197152410463699
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlantPot.prefab
+++ b/Assets/Prefabs/PlantPot.prefab
@@ -91,6 +91,7 @@ GameObject:
   - component: {fileID: 7215751098732819908}
   - component: {fileID: 3171973159409264124}
   - component: {fileID: 2598059880362052706}
+  - component: {fileID: 463886378190780142}
   m_Layer: 8
   m_Name: PlantPot
   m_TagString: Untagged
@@ -259,6 +260,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a40d5cf10b78010478f1683922e1cb9c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
+  ShowTopMostFoldoutHeaderGroup: 1
+--- !u!114 &463886378190780142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2838587713435855066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
   ShowTopMostFoldoutHeaderGroup: 1
 --- !u!1 &8536611091256278215
 GameObject:

--- a/Assets/Prefabs/PlantPot.prefab
+++ b/Assets/Prefabs/PlantPot.prefab
@@ -261,6 +261,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Plant Pot
 --- !u!114 &463886378190780142
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -819,7 +819,7 @@ CapsuleCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4288260960102316284}
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 13400000, guid: fcbd7e1d43024ec4cb0d8b262b422373, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -400,7 +400,7 @@ GameObject:
   - component: {fileID: 4991892091454183797}
   - component: {fileID: 6698906886167099103}
   - component: {fileID: 4919468137404618544}
-  - component: {fileID: 927732974370626359}
+  - component: {fileID: 8392673840019138378}
   m_Layer: 6
   m_Name: Player
   m_TagString: Player
@@ -479,6 +479,7 @@ MonoBehaviour:
     m_Bits: 448
   MoveSpeedMultiplier: 1
   JumpForceMultiplier: 1
+  InputOverride: {x: 0, y: 0}
 --- !u!114 &7087578872628324299
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -675,14 +676,14 @@ MonoBehaviour:
   _canvas: {fileID: 3879485635226405824}
   _text: {fileID: 3469528244901046127}
   _majorText: {fileID: 7676008789757717242}
---- !u!65 &927732974370626359
-BoxCollider:
+--- !u!136 &8392673840019138378
+CapsuleCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4288260960102316284}
-  m_Material: {fileID: 13400000, guid: fcbd7e1d43024ec4cb0d8b262b422373, type: 2}
+  m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -693,8 +694,10 @@ BoxCollider:
   m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.5, y: 1, z: 0.5}
+  serializedVersion: 2
+  m_Radius: 0.25
+  m_Height: 1
+  m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &6238399612091387915
 GameObject:

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -380,6 +380,143 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1 &2312518178949433948
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2250040325375048402}
+  - component: {fileID: 2988952699657167677}
+  - component: {fileID: 4258099003783671265}
+  m_Layer: 6
+  m_Name: Reticle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2250040325375048402
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2312518178949433948}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2983796501308078933}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2988952699657167677
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2312518178949433948}
+  m_CullTransparentMesh: 1
+--- !u!114 &4258099003783671265
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2312518178949433948}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: .
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 50
+  m_fontSizeBase: 50
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4288260960102316284
 GameObject:
   m_ObjectHideFlags: 0
@@ -479,7 +616,6 @@ MonoBehaviour:
     m_Bits: 448
   MoveSpeedMultiplier: 1
   JumpForceMultiplier: 1
-  InputOverride: {x: 0, y: 0}
 --- !u!114 &7087578872628324299
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1009,6 +1145,7 @@ RectTransform:
   - {fileID: 7795136547809546816}
   - {fileID: 671568095088813906}
   - {fileID: 3892688881236309029}
+  - {fileID: 2250040325375048402}
   m_Father: {fileID: 5475370442558850855}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -682,7 +682,7 @@ BoxCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4288260960102316284}
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 13400000, guid: fcbd7e1d43024ec4cb0d8b262b422373, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0

--- a/Assets/Prefabs/Potion.prefab
+++ b/Assets/Prefabs/Potion.prefab
@@ -106,6 +106,7 @@ GameObject:
   - component: {fileID: 4892682120741282943}
   - component: {fileID: 3108648740871576591}
   - component: {fileID: 5362075143917337665}
+  - component: {fileID: 592572199096519250}
   m_Layer: 8
   m_Name: Potion
   m_TagString: Untagged
@@ -274,8 +275,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
-  _followPositionAcceleration: 100
-  _followRotationAcceleration: 50
 --- !u!114 &5362075143917337665
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,3 +289,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Potion
   ShowTopMostFoldoutHeaderGroup: 1
   _breakSpeed: 10
+--- !u!114 &592572199096519250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4986591635374473630}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b7bcf61377355543a7fd7286e420628, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::StatusAffectable
+  ShowTopMostFoldoutHeaderGroup: 1

--- a/Assets/Prefabs/Potion.prefab
+++ b/Assets/Prefabs/Potion.prefab
@@ -275,6 +275,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Holdable
   ShowTopMostFoldoutHeaderGroup: 1
+  _hintName: Potion
 --- !u!114 &5362075143917337665
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PotionEffects/CloudBasePotionEffect.prefab
+++ b/Assets/Prefabs/PotionEffects/CloudBasePotionEffect.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 9155846370348866075}
   - component: {fileID: 5535828820224488313}
   - component: {fileID: 2447820062570008582}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: CloudBasePotionEffect
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -152,7 +152,7 @@ GameObject:
   - component: {fileID: 1427152477237292674}
   - component: {fileID: 5386639946044758723}
   - component: {fileID: 2692654945523034495}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Model
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/PotionEffects/CubeBasePotionEffect.prefab
+++ b/Assets/Prefabs/PotionEffects/CubeBasePotionEffect.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 1837083253497848568}
   - component: {fileID: 5699060183159732925}
   - component: {fileID: -4525584150150004491}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: CubeBasePotionEffect
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -212,7 +212,7 @@ GameObject:
   - component: {fileID: 2020721975739879872}
   - component: {fileID: 4160203676597686381}
   - component: {fileID: 320080909482816955}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Model
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/PotionEffects/CubeBasePotionEffect.prefab
+++ b/Assets/Prefabs/PotionEffects/CubeBasePotionEffect.prefab
@@ -1,5 +1,185 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1347371179006482910
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 687093145209632409}
+  - component: {fileID: 4319540091796894042}
+  - component: {fileID: 2128211175073855071}
+  m_Layer: 8
+  m_Name: Crystal1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &687093145209632409
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1347371179006482910}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.15694419, y: -0.028623406, z: -0.17712209, w: 0.97117305}
+  m_LocalPosition: {x: 0.402, y: 0.091, z: 0.125}
+  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 7844460446896280652}
+  m_LocalEulerAnglesHint: {x: 17.14, y: -6.682, z: -21.68}
+--- !u!23 &4319540091796894042
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1347371179006482910}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 683a1875feeb67646b5bb98068e79ffc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2128211175073855071
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1347371179006482910}
+  m_Mesh: {fileID: -9158669005730079536, guid: 3ede24733ba2e4f6982a967cad70bf15, type: 3}
+--- !u!1 &1872579480462419136
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7034667815586268932}
+  - component: {fileID: 1732982951552663285}
+  - component: {fileID: 7859527629010813117}
+  m_Layer: 8
+  m_Name: Crystal5
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7034667815586268932
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872579480462419136}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.17663248, y: 0.034952875, z: -0.18132037, w: 0.9668}
+  m_LocalPosition: {x: -0.415, y: -0.016, z: 0.01}
+  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 7844460446896280652}
+  m_LocalEulerAnglesHint: {x: -19.2, y: 8.013, z: -22.602}
+--- !u!23 &1732982951552663285
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872579480462419136}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 683a1875feeb67646b5bb98068e79ffc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &7859527629010813117
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872579480462419136}
+  m_Mesh: {fileID: -9158669005730079536, guid: 3ede24733ba2e4f6982a967cad70bf15, type: 3}
 --- !u!1 &2548020108679128396
 GameObject:
   m_ObjectHideFlags: 0
@@ -37,6 +217,12 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2020721975739879872}
+  - {fileID: 687093145209632409}
+  - {fileID: 3924216900593196820}
+  - {fileID: 4978928658196514759}
+  - {fileID: 4069137358942812102}
+  - {fileID: 7034667815586268932}
+  - {fileID: 9076856439800888622}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3985872948986551479
@@ -201,6 +387,96 @@ MonoBehaviour:
   UseRigidBodyForMotion: 0
   AutoUpdateKinematicState: 1
   AutoSetKinematicOnDespawn: 1
+--- !u!1 &3819744709565348537
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4069137358942812102}
+  - component: {fileID: 4613648067355170546}
+  - component: {fileID: 7352813646405786253}
+  m_Layer: 8
+  m_Name: Crystal4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4069137358942812102
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3819744709565348537}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.12224816, y: -0.2217295, z: 0.919758, w: 0.2998944}
+  m_LocalPosition: {x: -0.137, y: -0.375, z: -0.041}
+  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 7844460446896280652}
+  m_LocalEulerAnglesHint: {x: 28.764, y: 6.017, z: 145.426}
+--- !u!23 &4613648067355170546
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3819744709565348537}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 683a1875feeb67646b5bb98068e79ffc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &7352813646405786253
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3819744709565348537}
+  m_Mesh: {fileID: -9158669005730079536, guid: 3ede24733ba2e4f6982a967cad70bf15, type: 3}
 --- !u!1 &5104790431634454745
 GameObject:
   m_ObjectHideFlags: 0
@@ -291,3 +567,273 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5104790431634454745}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &5276831883491844576
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3924216900593196820}
+  - component: {fileID: 6651431903699860443}
+  - component: {fileID: 4694501887148951063}
+  m_Layer: 8
+  m_Name: Crystal2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3924216900593196820
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5276831883491844576}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.13113587, y: -0.09085241, z: 0.2395372, w: 0.9576906}
+  m_LocalPosition: {x: -0.178, y: 0.371, z: 0.095}
+  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 7844460446896280652}
+  m_LocalEulerAnglesHint: {x: 17.14, y: -6.682, z: 27.077}
+--- !u!23 &6651431903699860443
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5276831883491844576}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 683a1875feeb67646b5bb98068e79ffc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &4694501887148951063
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5276831883491844576}
+  m_Mesh: {fileID: -9158669005730079536, guid: 3ede24733ba2e4f6982a967cad70bf15, type: 3}
+--- !u!1 &6372045447776866729
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9076856439800888622}
+  - component: {fileID: 1416071268786164052}
+  - component: {fileID: 4527594647159586990}
+  m_Layer: 8
+  m_Name: Crystal6
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9076856439800888622
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6372045447776866729}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.64098704, y: -0.24089943, z: 0.08717617, w: 0.7235354}
+  m_LocalPosition: {x: -0.104, y: -0.221, z: -0.331}
+  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 7844460446896280652}
+  m_LocalEulerAnglesHint: {x: -62.32, y: -82.304, z: 69.449}
+--- !u!23 &1416071268786164052
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6372045447776866729}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 683a1875feeb67646b5bb98068e79ffc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &4527594647159586990
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6372045447776866729}
+  m_Mesh: {fileID: -9158669005730079536, guid: 3ede24733ba2e4f6982a967cad70bf15, type: 3}
+--- !u!1 &8998793646383138715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4978928658196514759}
+  - component: {fileID: 6685094308483757190}
+  - component: {fileID: 4258443214295405009}
+  m_Layer: 8
+  m_Name: Crystal3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4978928658196514759
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8998793646383138715}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0014100331, y: 0.23423003, z: 0.96991444, w: -0.06633508}
+  m_LocalPosition: {x: 0.014, y: -0.089, z: 0.373}
+  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 7844460446896280652}
+  m_LocalEulerAnglesHint: {x: -27.036, y: -1.823, z: 188.263}
+--- !u!23 &6685094308483757190
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8998793646383138715}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 683a1875feeb67646b5bb98068e79ffc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &4258443214295405009
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8998793646383138715}
+  m_Mesh: {fileID: -9158669005730079536, guid: 3ede24733ba2e4f6982a967cad70bf15, type: 3}

--- a/Assets/Prefabs/PotionEffects/NoBasePotionEffect.prefab
+++ b/Assets/Prefabs/PotionEffects/NoBasePotionEffect.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 7469290763348162868}
   - component: {fileID: 2855364821336431024}
   - component: {fileID: 1362748370711564188}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Model
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -102,7 +102,7 @@ GameObject:
   - component: {fileID: 6341308857714216744}
   - component: {fileID: 8938279990975762407}
   - component: {fileID: 3143509383519786549}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: NoBasePotionEffect
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -286,6 +286,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Fireboom
       objectReference: {fileID: 0}
+    - target: {fileID: 2680803822344808849, guid: 61f6613e6dcc49b449961964d16c1576, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
     - target: {fileID: 3047682132250550993, guid: 61f6613e6dcc49b449961964d16c1576, type: 3}
       propertyPath: lengthInSec
       value: 0.25
@@ -309,6 +313,10 @@ PrefabInstance:
     - target: {fileID: 3047682132250550993, guid: 61f6613e6dcc49b449961964d16c1576, type: 3}
       propertyPath: VelocityModule.speedModifier.scalar
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3151227542267437962, guid: 61f6613e6dcc49b449961964d16c1576, type: 3}
+      propertyPath: m_Layer
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 3871995083350419789, guid: 61f6613e6dcc49b449961964d16c1576, type: 3}
       propertyPath: lengthInSec
@@ -337,6 +345,10 @@ PrefabInstance:
     - target: {fileID: 3871995083350419789, guid: 61f6613e6dcc49b449961964d16c1576, type: 3}
       propertyPath: InitialModule.startSpeed.minMaxState
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4167040556123251932, guid: 61f6613e6dcc49b449961964d16c1576, type: 3}
+      propertyPath: m_Layer
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 4674305976061105573, guid: 61f6613e6dcc49b449961964d16c1576, type: 3}
       propertyPath: MaxDistance

--- a/Assets/Prefabs/PotionEffects/PuddleBasePotionEffect.prefab
+++ b/Assets/Prefabs/PotionEffects/PuddleBasePotionEffect.prefab
@@ -48,7 +48,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.Netcode.Runtime::Unity.Netcode.NetworkObject
-  GlobalObjectIdHash: 1181497194
+  GlobalObjectIdHash: 1049992388
   InScenePlacedSourceGlobalObjectIdHash: 4138189327
   DeferredDespawnTick: 0
   Ownership: 1
@@ -200,7 +200,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a9660d3938999f245b81a896fbfea96a, type: 2}
+  - {fileID: 2100000, guid: dfe28104d0ab8f248a5d7fd8a7a6283c, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefabs/PotionEffects/PuddleBasePotionEffect.prefab
+++ b/Assets/Prefabs/PotionEffects/PuddleBasePotionEffect.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 3955827139910508775}
   - component: {fileID: 1944947861877657522}
   - component: {fileID: 5135833739389691560}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: PuddleBasePotionEffect
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -153,7 +153,7 @@ GameObject:
   - component: {fileID: 9047077457014407119}
   - component: {fileID: 3770874244236953247}
   - component: {fileID: 8979222888723145791}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Model
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/PotionEffects/PuddleBasePotionEffect.prefab
+++ b/Assets/Prefabs/PotionEffects/PuddleBasePotionEffect.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 2212949455777814101}
   - component: {fileID: 3955827139910508775}
   - component: {fileID: 1944947861877657522}
-  - component: {fileID: 1476431536812158169}
+  - component: {fileID: 5135833739389691560}
   m_Layer: 0
   m_Name: PuddleBasePotionEffect
   m_TagString: Untagged
@@ -30,7 +30,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.356, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 2, y: 0.1, z: 2}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9047077457014407119}
@@ -120,8 +120,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PotionEffect
   ShowTopMostFoldoutHeaderGroup: 1
---- !u!65 &1476431536812158169
-BoxCollider:
+--- !u!64 &5135833739389691560
+MeshCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -135,12 +135,13 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1.75, y: 0.1, z: 1.75}
-  m_Center: {x: 0, y: 0, z: 0}
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &8280087967624297427
 GameObject:
   m_ObjectHideFlags: 0
@@ -169,7 +170,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 0.1, z: 2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 689857732435006186}

--- a/Assets/ScriptableObjects/Statuses/FireStatus.asset
+++ b/Assets/ScriptableObjects/Statuses/FireStatus.asset
@@ -14,3 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::FireStatus
   _id: 1
   _speedMultiplier: 1.5
+  _miasmaStatus: {fileID: 11400000, guid: 19afbb7df7c25cf4c851796fd27bd8d9, type: 2}

--- a/Assets/ScriptableObjects/Statuses/MiasmaStatus.asset
+++ b/Assets/ScriptableObjects/Statuses/MiasmaStatus.asset
@@ -14,8 +14,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::MiasmaStatus
   _id: 6
   _moveSpeedMultiplierDecreasePerSecond: 0.3
-  _moveSpeedMultiplierMin: 0.05
+  _moveSpeedMultiplierMin: 0.2
   _moveSpeedMultiplierMax: 0.75
   _jumpForceMultiplierDecreasePerSecond: 0.2
   _jumpForceMultiplierMin: 0.2
   _jumpForceMultiplierMax: 0.6
+  _fireStatus: {fileID: 11400000, guid: 4fec010c417574a43a0a16eac6fe4a07, type: 2}

--- a/Assets/Scripts/Alchemy/Cauldron.cs
+++ b/Assets/Scripts/Alchemy/Cauldron.cs
@@ -99,7 +99,19 @@ public class Cauldron : NetworkBehaviour, IInteractable
             _playersInside.Remove(playerPush);
         }
     }
-    
+
+    public string Hint()
+    {
+        if (_contents.Count > 0)
+        {
+            return "Brew Potion";
+        } 
+        else
+        {
+            return "";
+        }
+    }
+
     public void Interact()
     {
         BrewServerRpc();

--- a/Assets/Scripts/Alchemy/Cauldron.cs
+++ b/Assets/Scripts/Alchemy/Cauldron.cs
@@ -208,8 +208,14 @@ public class Cauldron : NetworkBehaviour, IInteractable
 
         foreach (var collider in Physics.OverlapSphere(_potionSpawnPoint.position, _explosionRadius))
         {
-            if (collider.TryGetComponent(out Rigidbody rb))
+            if (collider.TryGetComponent(out PlayerPush playerPush))
+            {
+                playerPush.AddExplosionForceClientRpc(_explosionForce, _potionSpawnPoint.position, _explosionRadius);
+            }
+            else if (collider.TryGetComponent(out Rigidbody rb))
+            {
                 rb.AddExplosionForce(_explosionForce, _potionSpawnPoint.position, _explosionRadius, 1f, ForceMode.Impulse);
+            }
 
             if (collider.TryGetComponent(out StatusAffectable statusAffectable))
                 statusAffectable.AddStatus(_explosionStatus, _explosionStatusDuration);

--- a/Assets/Scripts/Alchemy/Cauldron.cs
+++ b/Assets/Scripts/Alchemy/Cauldron.cs
@@ -95,7 +95,7 @@ public class Cauldron : NetworkBehaviour, IInteractable
         foreach (var playerPush in toExplode)
         {
             Vector3 launchForce = Vector3.up * _explosionForce;
-            playerPush.LaunchPlayerClientRpc(launchForce);
+            playerPush.AddForceClientRpc(launchForce);
             _playersInside.Remove(playerPush);
         }
     }

--- a/Assets/Scripts/Alchemy/IngredientEffects/BouncyModifierEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/BouncyModifierEffect.cs
@@ -29,12 +29,10 @@ public class BouncyModifierEffect : ModifierEffect
 
     public override void OnEffectUpdate(PotionEffect effect, CloudBaseEffect cloudBase, List<ModifierEffect> modifierEffects)
     {
-        if (!effect.IsServer) return;
-
         foreach (Collider collider in cloudBase.Affected)
         {
             if (collider != null && collider.TryGetComponent(out StatusAffectable statusAffectable))
-                statusAffectable.AddStatus(BouncyStatus, StatusDuration);
+                statusAffectable.AddStatus(BouncyStatus, 0.1f);
         }
     }
 

--- a/Assets/Scripts/Alchemy/IngredientEffects/CloudBaseEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/CloudBaseEffect.cs
@@ -10,6 +10,11 @@ public class CloudBaseEffect : BaseEffect
         
     }
 
+    public override void OnEffectSetup(PotionEffect effect)
+    {
+        effect.GetComponentInChildren<Renderer>().material.SetColor("_Color", effect.Color);
+    }
+
     public override void OnEffectTriggerEnter(Collider other, PotionEffect effect)
     {
         Affected.Add(other);

--- a/Assets/Scripts/Alchemy/IngredientEffects/CubeBaseEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/CubeBaseEffect.cs
@@ -4,8 +4,10 @@ using UnityEngine;
 
 public class CubeBaseEffect : BaseEffect
 {
-    public CubeBaseEffect(float duration) : base(duration)
-    {
-    }
+    public float AuraRadius;
 
+    public CubeBaseEffect(float duration, float auraRadius) : base(duration)
+    {
+        AuraRadius = auraRadius;
+    }
 }

--- a/Assets/Scripts/Alchemy/IngredientEffects/CubeBaseEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/CubeBaseEffect.cs
@@ -1,5 +1,4 @@
 
-using System.Collections.Generic;
 using UnityEngine;
 
 public class CubeBaseEffect : BaseEffect
@@ -9,5 +8,13 @@ public class CubeBaseEffect : BaseEffect
     public CubeBaseEffect(float duration, float auraRadius) : base(duration)
     {
         AuraRadius = auraRadius;
+    }
+
+    public override void OnEffectSetup(PotionEffect effect)
+    {
+        foreach (Renderer renderer in effect.GetComponentsInChildren<Renderer>())
+        {
+            renderer.material.SetColor("_BaseColor", effect.Color);
+        }
     }
 }

--- a/Assets/Scripts/Alchemy/IngredientEffects/FireModifierEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/FireModifierEffect.cs
@@ -12,6 +12,8 @@ public class FireModifierEffect : ModifierEffect
         FireStatusDuration = fireStatusDuration;
     }
 
+    // ── No base ──────────────────────────────────────────────
+    // Affected players/objects/miasma set on fire
     public override void OnEffectStart(PotionEffect effect, NoBaseEffect noBaseEffect, List<ModifierEffect> modifierEffects)
     {
         foreach (Collider collider in Physics.OverlapSphere(effect.transform.position, noBaseEffect.Radius))
@@ -23,6 +25,8 @@ public class FireModifierEffect : ModifierEffect
         MiasmaManager.Instance.DestroySphere(effect.transform.position, noBaseEffect.Radius);
     }
 
+    // ── Cloud base ──────────────────────────────────────────────
+    // Affected players/objects/miasma set on fire
     public override void OnEffectUpdate(PotionEffect effect, CloudBaseEffect cloudBaseEffect, List<ModifierEffect> modifierEffects)
     {
         foreach (Collider collider in cloudBaseEffect.Affected)
@@ -34,6 +38,8 @@ public class FireModifierEffect : ModifierEffect
         MiasmaManager.Instance.DestroySphere(effect.transform.position, effect.GetComponent<SphereCollider>().radius);
     }
 
+    // ── Cube base ──────────────────────────────────────────────
+    // Players/objects/miasma inside aura set on fire
     public override void OnEffectUpdate(PotionEffect effect, CubeBaseEffect cubeBaseEffect, List<ModifierEffect> modifierEffects)
     {   
         Vector3 halfExtents = effect.GetComponent<Collider>().bounds.size / 2 + Vector3.one * cubeBaseEffect.AuraRadius;
@@ -47,6 +53,8 @@ public class FireModifierEffect : ModifierEffect
         MiasmaManager.Instance.DestroySphere(effect.transform.position, halfExtents.magnitude);
     }
 
+    // ── Puddle base ──────────────────────────────────────────────
+    // Players/objects/miasma inside aura set on fire
     public override void OnEffectUpdate(PotionEffect effect, PuddleBaseEffect puddleBaseEffect, List<ModifierEffect> modifierEffects)
     {
         foreach (Collider collider in Physics.OverlapSphere(effect.transform.position, puddleBaseEffect.AuraRadius))

--- a/Assets/Scripts/Alchemy/IngredientEffects/FireModifierEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/FireModifierEffect.cs
@@ -14,9 +14,7 @@ public class FireModifierEffect : ModifierEffect
 
     public override void OnEffectStart(PotionEffect effect, NoBaseEffect noBaseEffect, List<ModifierEffect> modifierEffects)
     {
-        if (!effect.IsServer) return;
-
-        foreach (var collider in Physics.OverlapSphere(effect.transform.position, noBaseEffect.Radius))
+        foreach (Collider collider in Physics.OverlapSphere(effect.transform.position, noBaseEffect.Radius))
         {
             if (collider.TryGetComponent(out StatusAffectable statusAffectable))
                 statusAffectable.AddStatus(FireStatus, FireStatusDuration);
@@ -27,8 +25,6 @@ public class FireModifierEffect : ModifierEffect
 
     public override void OnEffectUpdate(PotionEffect effect, CloudBaseEffect cloudBaseEffect, List<ModifierEffect> modifierEffects)
     {
-        if (!effect.IsServer) return;
-
         foreach (Collider collider in cloudBaseEffect.Affected)
         {
             if (collider != null && collider.TryGetComponent(out StatusAffectable statusAffectable))
@@ -36,5 +32,29 @@ public class FireModifierEffect : ModifierEffect
         }
 
         MiasmaManager.Instance.DestroySphere(effect.transform.position, effect.GetComponent<SphereCollider>().radius);
+    }
+
+    public override void OnEffectUpdate(PotionEffect effect, CubeBaseEffect cubeBaseEffect, List<ModifierEffect> modifierEffects)
+    {   
+        Vector3 halfExtents = effect.GetComponent<Collider>().bounds.size / 2 + Vector3.one * cubeBaseEffect.AuraRadius;
+
+        foreach (Collider collider in Physics.OverlapBox(effect.transform.position, halfExtents))
+        {
+            if (collider.TryGetComponent(out StatusAffectable statusAffectable))
+                statusAffectable.AddStatus(FireStatus, FireStatusDuration);
+        }
+
+        MiasmaManager.Instance.DestroySphere(effect.transform.position, halfExtents.magnitude);
+    }
+
+    public override void OnEffectUpdate(PotionEffect effect, PuddleBaseEffect puddleBaseEffect, List<ModifierEffect> modifierEffects)
+    {
+        foreach (Collider collider in Physics.OverlapSphere(effect.transform.position, puddleBaseEffect.AuraRadius))
+        {
+            if (collider != null && collider.TryGetComponent(out StatusAffectable statusAffectable))
+                statusAffectable.AddStatus(FireStatus, FireStatusDuration);
+        }
+
+        MiasmaManager.Instance.DestroySphere(effect.transform.position, puddleBaseEffect.AuraRadius);
     }
 }

--- a/Assets/Scripts/Alchemy/IngredientEffects/FireModifierEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/FireModifierEffect.cs
@@ -21,16 +21,20 @@ public class FireModifierEffect : ModifierEffect
             if (collider.TryGetComponent(out StatusAffectable statusAffectable))
                 statusAffectable.AddStatus(FireStatus, FireStatusDuration);
         }        
+
+        MiasmaManager.Instance.DestroySphere(effect.transform.position, noBaseEffect.Radius);
     }
 
-    public override void OnEffectUpdate(PotionEffect effect, CloudBaseEffect baseEffect, List<ModifierEffect> modifierEffects)
+    public override void OnEffectUpdate(PotionEffect effect, CloudBaseEffect cloudBaseEffect, List<ModifierEffect> modifierEffects)
     {
         if (!effect.IsServer) return;
 
-        foreach (Collider collider in baseEffect.Affected)
+        foreach (Collider collider in cloudBaseEffect.Affected)
         {
             if (collider != null && collider.TryGetComponent(out StatusAffectable statusAffectable))
                 statusAffectable.AddStatus(FireStatus, FireStatusDuration);
         }
+
+        MiasmaManager.Instance.DestroySphere(effect.transform.position, effect.GetComponent<SphereCollider>().radius);
     }
 }

--- a/Assets/Scripts/Alchemy/IngredientEffects/FloatModifierEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/FloatModifierEffect.cs
@@ -61,21 +61,11 @@ public class FloatModifierEffect : ModifierEffect
     // ── Puddle base ──────────────────────────────────────────
     // Continuous upward force pushing away from puddle
 
-    public override void OnEffectTriggerEnter(Collider other, PotionEffect effect, PuddleBaseEffect puddleBase, List<ModifierEffect> modifierEffects)
-    {
-        _puddleAffected.Add(other);
-    }
-
-    public override void OnEffectTriggerExit(Collider other, PotionEffect effect, PuddleBaseEffect puddleBase, List<ModifierEffect> modifierEffects)
-    {
-        _puddleAffected.Remove(other);
-    }
-
     public override void OnEffectUpdate(PotionEffect effect, PuddleBaseEffect puddleBase, List<ModifierEffect> modifierEffects)
     {
         if (!effect.IsServer) return;
 
-        foreach (Collider collider in _puddleAffected)
+        foreach (Collider collider in Physics.OverlapSphere(effect.transform.position, puddleBase.AuraRadius))
         {
             if (collider == null) continue;
 

--- a/Assets/Scripts/Alchemy/IngredientEffects/FloatModifierEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/FloatModifierEffect.cs
@@ -8,8 +8,6 @@ public class FloatModifierEffect : ModifierEffect
     public float CubeDrag;
     public float PuddleUpwardForce;
 
-    private HashSet<Collider> _puddleAffected = new();
-
     public FloatModifierEffect(Status floatStatus, float statusDuration, float cubeDrag, float puddleUpwardForce)
     {
         FloatStatus = floatStatus;
@@ -42,7 +40,7 @@ public class FloatModifierEffect : ModifierEffect
         foreach (Collider collider in cloudBase.Affected)
         {
             if (collider != null && collider.TryGetComponent(out StatusAffectable statusAffectable))
-                statusAffectable.AddStatus(FloatStatus, StatusDuration);
+                statusAffectable.AddStatus(FloatStatus, 0.1f);
         }
     }
 
@@ -63,21 +61,24 @@ public class FloatModifierEffect : ModifierEffect
 
     public override void OnEffectUpdate(PotionEffect effect, PuddleBaseEffect puddleBase, List<ModifierEffect> modifierEffects)
     {
-        if (!effect.IsServer) return;
-
         foreach (Collider collider in Physics.OverlapSphere(effect.transform.position, puddleBase.AuraRadius))
         {
             if (collider == null) continue;
 
-            // Players: apply status (gravity disabled via FloatStatus)
+            // Apply status (gravity disabled via FloatStatus)
             if (collider.TryGetComponent(out StatusAffectable statusAffectable))
             {
                 statusAffectable.AddStatus(FloatStatus, StatusDuration);
             }
-            // Non-player rigidbodies: apply upward force directly on server
-            else if (collider.TryGetComponent(out Rigidbody rb))
+
+            // Apply force on server or client
+            if (collider.TryGetComponent(out PlayerPush playerPush))
             {
-                rb.AddForce(Vector3.up * PuddleUpwardForce, ForceMode.Force);
+                playerPush.AddForceClientRpc(PuddleUpwardForce * Vector3.up * Time.deltaTime);
+            }
+            else if (collider.TryGetComponent(out Rigidbody rb))
+            { 
+                rb.AddForce(Vector3.up * PuddleUpwardForce * Time.deltaTime, ForceMode.Force);
             }
         }
     }

--- a/Assets/Scripts/Alchemy/IngredientEffects/NoBaseEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/NoBaseEffect.cs
@@ -16,10 +16,10 @@ public class NoBaseEffect : BaseEffect
     {
         foreach (var collider in Physics.OverlapSphere(effect.transform.position, Radius))
         {
-            // Check to see if we hit a player first, if its owned by the server, we don't need to go through the ClientRpc I think?
-            if (collider.CompareTag("Player") && !collider.GetComponent<NetworkObject>().IsOwnedByServer)
+            // Apply explosion force to affected players and objects
+            if (collider.TryGetComponent(out PlayerPush playerPush))
             {
-                collider.GetComponent<PlayerPush>().ApplyForceToPlayerClientRpc(ExplosionForce, effect.transform.position, Radius);
+                playerPush.AddExplosionForceClientRpc(ExplosionForce, effect.transform.position, Radius);
             }
             else if (collider.TryGetComponent(out Rigidbody rb)) // Then handle server Authoritative parts
             {

--- a/Assets/Scripts/Alchemy/IngredientEffects/PuddleBaseEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/PuddleBaseEffect.cs
@@ -11,4 +11,9 @@ public class PuddleBaseEffect : BaseEffect
     {
         AuraRadius = auraRadius;
     }
+
+    public override void OnEffectSetup(PotionEffect effect)
+    {
+        effect.GetComponentInChildren<Renderer>().material.SetColor("_Color", effect.Color);
+    }
 }

--- a/Assets/Scripts/Alchemy/IngredientEffects/PuddleBaseEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/PuddleBaseEffect.cs
@@ -4,8 +4,11 @@ using UnityEngine;
 
 public class PuddleBaseEffect : BaseEffect
 {
-    public PuddleBaseEffect(float duration) : base(duration)
-    {
-    }
 
+    public float AuraRadius;
+
+    public PuddleBaseEffect(float duration, float auraRadius) : base(duration)
+    {
+        AuraRadius = auraRadius;
+    }
 }

--- a/Assets/Scripts/Alchemy/IngredientEffects/SizeModifierEffect.cs
+++ b/Assets/Scripts/Alchemy/IngredientEffects/SizeModifierEffect.cs
@@ -10,17 +10,29 @@ public class SizeModifierEffect : ModifierEffect
         ScaleMultiplier = scaleMultiplier;
     }
 
-    // NO BASE
+    // ── No base ──────────────────────────────────────────────
     public override void OnEffectSetup(PotionEffect effect, NoBaseEffect baseEffect, List<ModifierEffect> modifierEffects)
     {
         baseEffect.Radius *= ScaleMultiplier;
         effect.transform.localScale *= ScaleMultiplier;
     }
 
-    // CLOUD BASE
+    // ── Cloud base ──────────────────────────────────────────────
     public override void OnEffectSetup(PotionEffect effect, CloudBaseEffect baseEffect, List<ModifierEffect> modifierEffects)
     {
         effect.transform.localScale *= ScaleMultiplier;
     }
 
+    // ── Cube base ──────────────────────────────────────────────
+    public override void OnEffectSetup(PotionEffect effect, CubeBaseEffect baseEffect, List<ModifierEffect> modifierEffects)
+    {
+        effect.transform.localScale *= ScaleMultiplier;
+    }
+
+    // ── Puddle base ──────────────────────────────────────────────
+    public override void OnEffectSetup(PotionEffect effect, PuddleBaseEffect baseEffect, List<ModifierEffect> modifierEffects)
+    {
+        baseEffect.AuraRadius *= ScaleMultiplier;
+        effect.transform.localScale = new Vector3(effect.transform.localScale.x * ScaleMultiplier, effect.transform.localScale.y, effect.transform.localScale.z * ScaleMultiplier);
+    }
 }

--- a/Assets/Scripts/Alchemy/IngredientTypes/CubeBaseType.cs
+++ b/Assets/Scripts/Alchemy/IngredientTypes/CubeBaseType.cs
@@ -3,8 +3,10 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "CubeBase", menuName = "ScriptableObjects/IngredientType/CubeBase")]
 public class CubeBaseIngredientType : BaseIngredientType
 {
+    [SerializeField] private float _auraRadius = 0.5f;
+    public float AuraRadius => _auraRadius;
     public override IngredientEffect CreateEffect()
     {
-        return new CubeBaseEffect(Duration);
+        return new CubeBaseEffect(Duration, AuraRadius);
     }
 }

--- a/Assets/Scripts/Alchemy/IngredientTypes/PuddleBaseType.cs
+++ b/Assets/Scripts/Alchemy/IngredientTypes/PuddleBaseType.cs
@@ -3,8 +3,11 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "PuddleBase", menuName = "ScriptableObjects/IngredientType/PuddleBase")]
 public class PuddleBaseIngredientType : BaseIngredientType
 {
+    [SerializeField] private float _auraRadius = 1f;
+    public float AuraRadius => _auraRadius;
+
     public override IngredientEffect CreateEffect()
     {
-        return new PuddleBaseEffect(Duration);
+        return new PuddleBaseEffect(Duration, AuraRadius);
     }
 }

--- a/Assets/Scripts/Alchemy/PanaceaCauldron.cs
+++ b/Assets/Scripts/Alchemy/PanaceaCauldron.cs
@@ -58,7 +58,7 @@ public class PanaceaCauldron : NetworkBehaviour
     {
         if (_playersInside.Count == 0) return;
 
-        foreach (var key in _playersInside.Keys)
+        foreach (var key in new List<PlayerPush>(_playersInside.Keys))
         {
             _playersInside[key] += Time.deltaTime;
 

--- a/Assets/Scripts/Alchemy/PanaceaCauldron.cs
+++ b/Assets/Scripts/Alchemy/PanaceaCauldron.cs
@@ -65,7 +65,7 @@ public class PanaceaCauldron : NetworkBehaviour
             if (_playersInside[key] >= _playerStuckTime)
             {
                 Vector3 launchForce = Vector3.up * _explosionForce;
-                key.LaunchPlayerClientRpc(launchForce);
+                key.AddForceClientRpc(launchForce);
                 _playersInside.Remove(key);
             }
         }

--- a/Assets/Scripts/Alchemy/Potion.cs
+++ b/Assets/Scripts/Alchemy/Potion.cs
@@ -17,6 +17,7 @@ public class Potion : NetworkBehaviour
 
     private int _baseIngredientId;
     private List<int> _modifierIngredientIds = new();
+    private Color _color;
     private Renderer _renderer;
     private Rigidbody _rb;
     public Rigidbody Rb => _rb;
@@ -86,7 +87,8 @@ public class Potion : NetworkBehaviour
             sum += ((IngredientType)modifierIngredientId).Color;
         }
 
-        _renderer.material.color = sum / (1f + _modifierIngredientIds.Count);
+        _color = sum / (1f + _modifierIngredientIds.Count);
+        _renderer.material.color = _color;
     }
 
     /// OnCollisionEnter
@@ -108,7 +110,7 @@ public class Potion : NetworkBehaviour
 
         PotionEffect effect = Instantiate(((BaseIngredientType)_baseIngredientId).PotionEffectPrefab, contact.point, rotation);
 
-        effect.Initialize(_baseIngredientId, _modifierIngredientIds);
+        effect.Initialize(_baseIngredientId, _modifierIngredientIds, _color);
         effect.NetworkObject.Spawn();
 
         NetworkObject.Despawn();

--- a/Assets/Scripts/Alchemy/PotionEffect.cs
+++ b/Assets/Scripts/Alchemy/PotionEffect.cs
@@ -9,17 +9,20 @@ public class PotionEffect : NetworkBehaviour
     private List<int> _modifierEffectIds = new();
     private BaseEffect _baseEffect;
     private List<ModifierEffect> _modifierEffects = new();
+    private Color _color;
+    public Color Color => _color;
 
     private NetworkVariable<int> _baseEffectIdNetwork = new();
     private NetworkList<int> _modifierEffectIdsNetwork = new();
 
-    public void Initialize(int baseIngredientId, List<int> modifierEffectIds)
+    public void Initialize(int baseIngredientId, List<int> modifierEffectIds, Color color)
     {
         _baseEffectId = baseIngredientId;
         foreach (var modifierEffectId in modifierEffectIds)
         {
             _modifierEffectIds.Add(modifierEffectId);
         }
+        _color = color;
     }
 
     public override void OnNetworkSpawn()

--- a/Assets/Scripts/Miasma/MiasmaManager.cs
+++ b/Assets/Scripts/Miasma/MiasmaManager.cs
@@ -25,7 +25,7 @@ public class MiasmaManager : NetworkBehaviour
 
     [Header("Status")]
     [SerializeField] private Status _status;
-    [SerializeField] private CapsuleCollider _playerCollider;
+    [SerializeField] private Collider _playerCollider;
     [SerializeField] private float _lossTimeThreshold = 5f;
 
     [Header("Debug")]

--- a/Assets/Scripts/Miasma/MiasmaManager.cs
+++ b/Assets/Scripts/Miasma/MiasmaManager.cs
@@ -1,13 +1,15 @@
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using Unity.Netcode;
 using Random = UnityEngine.Random;
+using System;
 
 public class MiasmaManager : NetworkBehaviour
 {
 
     public static MiasmaManager Instance;
+
+    public event EventHandler OnUpdate;
 
     [Header("Grid")]
     [SerializeField] private float _cellSize = 0.5f;
@@ -38,13 +40,12 @@ public class MiasmaManager : NetworkBehaviour
     private Node[,,] _grid;
     private HashSet<Node> _allNodes;
     private HashSet<Node> _activeNodes;
+    private bool _activeNodesDirty;
     private Vector3Int _playerCellExtents;
     private float _lossTimer = 0f;
 
     private NetworkList<Vector3Int> _activeCells;
     public NetworkList<Vector3Int> ActiveCells => _activeCells;
-    private NetworkVariable<bool> _isBatchUpdate;
-    public NetworkVariable<bool> IsBatchUpdate => _isBatchUpdate;
 
     private void Awake()
     {
@@ -53,7 +54,6 @@ public class MiasmaManager : NetworkBehaviour
         _allNodes = new();
         _activeNodes = new();
         _activeCells = new NetworkList<Vector3Int>();
-        _isBatchUpdate = new();
         _playerCellExtents = CalculatePlayerCellExtents();
     }
 
@@ -86,8 +86,6 @@ public class MiasmaManager : NetworkBehaviour
                 }
             }
             
-            _isBatchUpdate.Value = false;        
-
             InvokeRepeating(nameof(Grow), _growthInterval, _growthInterval);  
         }
     }
@@ -113,6 +111,8 @@ public class MiasmaManager : NetworkBehaviour
                 _activeNodes.Clear();
                 break;
         }
+
+        _activeNodesDirty = true;
     }
 
     public void AddNode(Node node)
@@ -212,24 +212,10 @@ public class MiasmaManager : NetworkBehaviour
             }
         }
 
-        BatchUpdate(nodesToActivate);
-    }
-
-    private void BatchUpdate(List<Node> nodesToActivate)
-    {
-        if (nodesToActivate.Count == 0) return;
-
-        _isBatchUpdate.Value = true;
-        Node firstNode = nodesToActivate.First();
-        nodesToActivate.Remove(firstNode);
-
         foreach (Node node in nodesToActivate)
         {
             ActivateNode(node);
         }
-
-        _isBatchUpdate.Value = false;
-        ActivateNode(firstNode);
     }
 
     public Vector3Int WorldToGrid(Vector3 worldPos)
@@ -291,6 +277,15 @@ public class MiasmaManager : NetworkBehaviour
 
             Next:;
         }       
+    }
+
+    private void LateUpdate()
+    {
+        if (_activeNodesDirty)
+        {
+            OnUpdate?.Invoke(this, EventArgs.Empty);
+            _activeNodesDirty = false;
+        }
     }
 
     [Rpc(SendTo.Everyone, InvokePermission = RpcInvokePermission.Everyone)]

--- a/Assets/Scripts/Miasma/MiasmaManager.cs
+++ b/Assets/Scripts/Miasma/MiasmaManager.cs
@@ -297,6 +297,32 @@ public class MiasmaManager : NetworkBehaviour
         }
     }
 
+    public void DestroySphere(Vector3 worldPos, float radius)
+    {
+        DestroySphereRpc(worldPos, radius);
+    }
+
+    [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)]
+    private void DestroySphereRpc(Vector3 worldPos, float radius)
+    {
+        Vector3Int center = WorldToGrid(worldPos);
+        int cellRadius = Mathf.CeilToInt(radius / CellSize);
+
+        for (int x = -cellRadius; x <= cellRadius; x++)
+        for (int y = -cellRadius; y <= cellRadius; y++)
+        for (int z = -cellRadius; z <= cellRadius; z++)
+        {
+            Vector3Int coord = center + new Vector3Int(x, y, z);
+            if (!InBounds(coord)) continue;
+
+            Node node = GetNode(coord);
+            if (IsNodeActive(node))
+            {
+                DeactivateNode(node);
+            }
+        }
+    }
+
     private void OnDrawGizmos()
     {
         if (!_debugDraw) return;

--- a/Assets/Scripts/Miasma/MiasmaManager.cs
+++ b/Assets/Scripts/Miasma/MiasmaManager.cs
@@ -71,21 +71,8 @@ public class MiasmaManager : NetworkBehaviour
     {
         _activeCells.OnListChanged += OnActiveCellsChanged;
 
-        foreach (Vector3Int coord in _activeCells)
-        {
-            _activeNodes.Add(GetNode(coord));
-        }
-
         if (IsServer)
-        {    
-            foreach (Node node in _allNodes)
-            {
-                if (node.startActive)
-                {
-                    ActivateNode(node);   
-                }
-            }
-            
+        {
             InvokeRepeating(nameof(Grow), _growthInterval, _growthInterval);  
         }
     }
@@ -100,7 +87,11 @@ public class MiasmaManager : NetworkBehaviour
         switch (changeEvent.Type)
         {
             case NetworkListEvent<Vector3Int>.EventType.Add:
-                _activeNodes.Add(GetNode(changeEvent.Value));
+                Node node = GetNode(changeEvent.Value);
+                if (_allNodes.Contains(node))
+                {
+                    _activeNodes.Add(node);
+                }
                 break;
 
             case NetworkListEvent<Vector3Int>.EventType.Remove:
@@ -125,10 +116,22 @@ public class MiasmaManager : NetworkBehaviour
         {
             _grid[coord.x, coord.y, coord.z] = node;
             _allNodes.Add(node);
+
+            if (node.startActive || _activeCells.Contains(node.coord))
+            {
+                _activeNodes.Add(node);
+                ActivateNode(node);
+            }
         }
         else
         {
             MergeNodes(currentNode, node);
+
+            if ((node.startActive || _activeCells.Contains(node.coord)) && !_activeNodes.Contains(currentNode))
+            {
+                _activeNodes.Add(currentNode);
+                ActivateNode(currentNode);
+            }
         }
     }
 

--- a/Assets/Scripts/Miasma/MiasmaMesh.cs
+++ b/Assets/Scripts/Miasma/MiasmaMesh.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using Unity.Netcode;
 using System.Collections.Generic;
+using System;
 
 public class MiasmaMesh : NetworkBehaviour 
 {
@@ -8,7 +9,6 @@ public class MiasmaMesh : NetworkBehaviour
     private Mesh _mesh;
     private MeshRenderer _meshRenderer;
     public float tileScale = 1f;
-    private bool _isBatchUpdate;
 
     private void Start()
     {
@@ -23,27 +23,17 @@ public class MiasmaMesh : NetworkBehaviour
 
     public override void OnNetworkSpawn()
     {
-        MiasmaManager.Instance.ActiveCells.OnListChanged += OnActiveCellsChanged;
-        MiasmaManager.Instance.IsBatchUpdate.OnValueChanged += OnBatchUpdate;
+        MiasmaManager.Instance.OnUpdate += OnUpdate;
     }
 
     public override void OnNetworkDespawn()
     {
-        MiasmaManager.Instance.ActiveCells.OnListChanged -= OnActiveCellsChanged;
-        MiasmaManager.Instance.IsBatchUpdate.OnValueChanged -= OnBatchUpdate;
+        MiasmaManager.Instance.OnUpdate -= OnUpdate;
     }
 
-    private void OnBatchUpdate(bool previous, bool current)
-    {  
-        _isBatchUpdate = current;
-    }
-
-    private void OnActiveCellsChanged(NetworkListEvent<Vector3Int> changeEvent)
+    private void OnUpdate(object sender, EventArgs e)
     {
-        if (!_isBatchUpdate)
-        {
-            Redraw();
-        }
+        Redraw();
     }
 
     private void Redraw()

--- a/Assets/Scripts/Network/NetworkClient.cs
+++ b/Assets/Scripts/Network/NetworkClient.cs
@@ -21,6 +21,7 @@ public class NetworkClient : NetworkBehaviour
     private AudioListener _audioListener;
     private PlayerUI _playerUI;
     private Camera _uiCamera;
+    private Canvas _uiCanvas;
 
     private void Awake()
     {
@@ -32,6 +33,7 @@ public class NetworkClient : NetworkBehaviour
         _playerCamera = GetComponentInChildren<Camera>();
         _audioListener = GetComponentInChildren<AudioListener>();
         _playerUI = GetComponent<PlayerUI>();
+        _uiCanvas = GetComponentInChildren<Canvas>();
         _uiCamera = _playerCamera.gameObject.GetComponentInChildren<Camera>();
 
         _playerInput.enabled = false;
@@ -43,6 +45,7 @@ public class NetworkClient : NetworkBehaviour
         _audioListener.enabled = false;
         _playerUI.enabled = false;
         _uiCamera.enabled = false;
+        _uiCanvas.enabled = false;
     }
 
     public override void OnNetworkSpawn()
@@ -60,6 +63,7 @@ public class NetworkClient : NetworkBehaviour
             _audioListener.enabled = true;
             _playerUI.enabled = true;
             _uiCamera.enabled = true;
+            _uiCanvas.enabled = true;
         }
 
         if (IsServer)

--- a/Assets/Scripts/Object/Flammable.cs
+++ b/Assets/Scripts/Object/Flammable.cs
@@ -1,0 +1,19 @@
+
+using Unity.Netcode;
+using UnityEngine;
+
+[RequireComponent(typeof(StatusAffectable))]
+public class Flammable : NetworkBehaviour
+{
+    [SerializeField] private float durability = 2f;
+
+    public void Burn(float duration)
+    {
+        durability -= duration;
+
+        if (durability <= 0f)
+        {
+            NetworkObject.Despawn(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Object/Flammable.cs.meta
+++ b/Assets/Scripts/Object/Flammable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 407d11308096f574a8e5564ceebb2b97

--- a/Assets/Scripts/Object/Holdable.cs
+++ b/Assets/Scripts/Object/Holdable.cs
@@ -4,6 +4,10 @@ using UnityEngine;
 [RequireComponent(typeof(Rigidbody))]
 public class Holdable : NetworkBehaviour
 {
+
+    [SerializeField] private string _hintName;
+    public string HintName => _hintName;
+
     private Rigidbody _rb;
     private Transform _holdPoint;
     private bool _isHeld = false;

--- a/Assets/Scripts/Object/IInteractable.cs
+++ b/Assets/Scripts/Object/IInteractable.cs
@@ -1,5 +1,8 @@
 
+using UnityEngine;
+
 public interface IInteractable
 {
+    public string Hint();
     public abstract void Interact();
 }

--- a/Assets/Scripts/Player/PlayerInteract.cs
+++ b/Assets/Scripts/Player/PlayerInteract.cs
@@ -52,14 +52,13 @@ public class PlayerInteract : NetworkBehaviour
             return;
         }
 
-        if (hit.collider.TryGetComponent(out Holdable holdable) && !holdable.IsHeld)
+        if (hit.collider.TryGetComponent(out IInteractable interactable))
         {
-            string objectName = holdable.gameObject.name.Replace("(Clone)", "").Trim();
-            string hint = holdable.GetComponent<Ingredient>() != null
-                ? $"[LMB] Pick up {objectName} (ingredient)"
-                : $"[LMB] Pick up {objectName}";
-
-            _playerUI.Show(hint);
+            _playerUI.Show($"{interactable.Hint()}");
+        }
+        else if (hit.collider.TryGetComponent(out Holdable holdable))
+        {
+            _playerUI.Show($"Pick up {holdable.HintName}");
         }
         else
         {

--- a/Assets/Scripts/Player/PlayerMove.cs
+++ b/Assets/Scripts/Player/PlayerMove.cs
@@ -25,6 +25,7 @@ public class PlayerMove : MonoBehaviour
 
     [HideInInspector] public float MoveSpeedMultiplier = 1f;
     [HideInInspector] public float JumpForceMultiplier = 1f;
+    [HideInInspector] public Vector2 InputOverride = Vector2.zero;
 
     private void Start()
     {
@@ -51,7 +52,14 @@ public class PlayerMove : MonoBehaviour
 
     private void OnMove(InputValue value)
     {
-        _moveInput = value.Get<Vector2>();
+        if (InputOverride != Vector2.zero)
+        {
+            _moveInput = InputOverride;
+        } 
+        else
+        {
+            _moveInput = value.Get<Vector2>();
+        }
     }
 
     private void OnJump()

--- a/Assets/Scripts/Player/PlayerMove.cs
+++ b/Assets/Scripts/Player/PlayerMove.cs
@@ -22,10 +22,11 @@ public class PlayerMove : MonoBehaviour
     private RaycastHit _groundHit;
     private Vector3 _platformVelocity; // velocity sampled from a MovingPlatform when standing on one
     private Transform _currentPlatform;
+    private bool _isInputOverridden = false;
+    private Vector2 _inputOverride = Vector2.zero;
 
     [HideInInspector] public float MoveSpeedMultiplier = 1f;
     [HideInInspector] public float JumpForceMultiplier = 1f;
-    [HideInInspector] public Vector2 InputOverride = Vector2.zero;
 
     private void Start()
     {
@@ -52,14 +53,7 @@ public class PlayerMove : MonoBehaviour
 
     private void OnMove(InputValue value)
     {
-        if (InputOverride != Vector2.zero)
-        {
-            _moveInput = InputOverride;
-        } 
-        else
-        {
-            _moveInput = value.Get<Vector2>();
-        }
+        _moveInput = value.Get<Vector2>();
     }
 
     private void OnJump()
@@ -69,6 +63,11 @@ public class PlayerMove : MonoBehaviour
 
     private void Move()
     {
+        if (_isInputOverridden)
+        {
+            _moveInput = _inputOverride;
+        } 
+
         float horizontalSpeed = Vector3.Magnitude(new Vector3(_rb.linearVelocity.x, 0f, _rb.linearVelocity.z));
         if (horizontalSpeed > _baseMaxMoveSpeed * MoveSpeedMultiplier) return;
 
@@ -136,5 +135,18 @@ public class PlayerMove : MonoBehaviour
         }
 
         return Vector3.Angle(_groundHit.normal, Vector3.up) <= _maxGroundAngle;
+    }
+
+    public void OverrideInput(Vector2 input)
+    {
+        _inputOverride = input;
+        _isInputOverridden = true;
+    }
+
+    public void ClearInputOverride()
+    {
+        _inputOverride = Vector2.zero;
+        _isInputOverridden = false;
+        _moveInput = Vector2.zero;
     }
 }

--- a/Assets/Scripts/Player/PlayerPush.cs
+++ b/Assets/Scripts/Player/PlayerPush.cs
@@ -37,18 +37,16 @@ public class PlayerPush : NetworkBehaviour
     }
 
     [Rpc(SendTo.Owner, InvokePermission = RpcInvokePermission.Everyone)]
-    public void ApplyForceToPlayerClientRpc(float ExplosionForce, Vector3 ForceOrigin, float ExplosionRadius)
+    public void AddExplosionForceClientRpc(float explosionForce, Vector3 forceOrigin, float explosionRadius)
     {
-        // THIS SHOULD WORK?
-        gameObject.GetComponent<Rigidbody>().AddExplosionForce(ExplosionForce, ForceOrigin, ExplosionRadius, 1f, ForceMode.Impulse);
-        Debug.Log($"Applied {ExplosionForce} force to player on the client-side from the point: {ForceOrigin}");
+        _rb.AddExplosionForce(explosionForce, forceOrigin, explosionRadius, 1f, ForceMode.Impulse);
+        Debug.Log($"Applied {explosionForce} force to player on the client-side from the point: {forceOrigin}");
     }
 
     [Rpc(SendTo.Owner, InvokePermission = RpcInvokePermission.Everyone)]
-    public void LaunchPlayerClientRpc(Vector3 force)
+    public void AddForceClientRpc(Vector3 force, ForceMode mode = ForceMode.Impulse)
     {
-        _rb.linearVelocity = new Vector3(_rb.linearVelocity.x, 0f, _rb.linearVelocity.z);
-        _rb.AddForce(force, ForceMode.Impulse);
+        _rb.AddForce(force, mode);
         Debug.Log($"[Cauldron] Launched player with force: {force}");
     }
 }

--- a/Assets/Scripts/Status/FireStatus.cs
+++ b/Assets/Scripts/Status/FireStatus.cs
@@ -4,12 +4,14 @@ using UnityEngine;
 public class FireStatus : Status
 {
     [SerializeField] private float _speedMultiplier = 1.5f;
+    [SerializeField] private Vector2 _inputOverride = Vector2.up;
 
     public override void OnStatusStart(GameObject target)
     {
         if (target.TryGetComponent(out PlayerMove playerMove))
         {
-            playerMove.MoveSpeedMultiplier *= _speedMultiplier;
+            playerMove.MoveSpeedMultiplier = _speedMultiplier;
+            playerMove.InputOverride = _inputOverride;
         }
     }
 
@@ -17,7 +19,8 @@ public class FireStatus : Status
     {
         if (target.TryGetComponent(out PlayerMove playerMove))
         {
-            playerMove.MoveSpeedMultiplier *= 1f / _speedMultiplier;
+            playerMove.MoveSpeedMultiplier = 1f;
+            playerMove.InputOverride = Vector2.zero;
         }
     }
 }

--- a/Assets/Scripts/Status/FireStatus.cs
+++ b/Assets/Scripts/Status/FireStatus.cs
@@ -15,6 +15,14 @@ public class FireStatus : Status
         }
     }
 
+    public override void OnStatusFixedUpdate(GameObject target)
+    {
+        if (target.TryGetComponent(out Flammable flammable))
+        {
+            flammable.Burn(Time.fixedDeltaTime);
+        }
+    }
+
     public override void OnStatusEnd(GameObject target)
     {
         if (target.TryGetComponent(out PlayerMove playerMove))

--- a/Assets/Scripts/Status/FireStatus.cs
+++ b/Assets/Scripts/Status/FireStatus.cs
@@ -11,7 +11,7 @@ public class FireStatus : Status
         if (target.TryGetComponent(out PlayerMove playerMove))
         {
             playerMove.MoveSpeedMultiplier = _speedMultiplier;
-            playerMove.InputOverride = _inputOverride;
+            playerMove.OverrideInput(_inputOverride);
         }
     }
 
@@ -28,7 +28,7 @@ public class FireStatus : Status
         if (target.TryGetComponent(out PlayerMove playerMove))
         {
             playerMove.MoveSpeedMultiplier = 1f;
-            playerMove.InputOverride = Vector2.zero;
+            playerMove.ClearInputOverride();
         }
     }
 }

--- a/Assets/Scripts/Status/MiasmaStatus.cs
+++ b/Assets/Scripts/Status/MiasmaStatus.cs
@@ -9,27 +9,23 @@ public class MiasmaStatus : Status
     [SerializeField] private float _jumpForceMultiplierDecreasePerSecond = 0.1f;
     [SerializeField] private float _jumpForceMultiplierMin = 0.1f;
     [SerializeField] private float _jumpForceMultiplierMax = 0.5f;
-
-    public override void OnStatusStart(GameObject target)
-    {
-        if (target.TryGetComponent(out PlayerMove playerMove))
-        {
-            playerMove.MoveSpeedMultiplier = _moveSpeedMultiplierMax;
-            playerMove.JumpForceMultiplier = _jumpForceMultiplierMax;
-        }
-    }
+    [SerializeField] private Status _fireStatus;
 
     public override void OnStatusFixedUpdate(GameObject target)
     {
+        if (target.GetComponent<StatusAffectable>().HasStatus(_fireStatus)) return;
+
         if (target.TryGetComponent(out PlayerMove playerMove))
         {
             if (playerMove.MoveSpeedMultiplier > _moveSpeedMultiplierMin)
             {            
                 playerMove.MoveSpeedMultiplier -= _moveSpeedMultiplierDecreasePerSecond * Time.fixedDeltaTime;
+                playerMove.MoveSpeedMultiplier = Mathf.Max(playerMove.MoveSpeedMultiplier, _moveSpeedMultiplierMin);
             }
             if (playerMove.JumpForceMultiplier > _jumpForceMultiplierMin)
             {
                 playerMove.JumpForceMultiplier -= _jumpForceMultiplierDecreasePerSecond * Time.fixedDeltaTime;
+                playerMove.JumpForceMultiplier = Mathf.Max(playerMove.JumpForceMultiplier, _jumpForceMultiplierMin);
             }
         }
     }
@@ -38,8 +34,12 @@ public class MiasmaStatus : Status
     {
         if (target.TryGetComponent(out PlayerMove playerMove))
         {
-            playerMove.MoveSpeedMultiplier = 1f;
             playerMove.JumpForceMultiplier = 1f;
+
+            if (!target.GetComponent<StatusAffectable>().HasStatus(_fireStatus)) 
+            {
+                playerMove.MoveSpeedMultiplier = 1f;
+            }
         }
     }
 }

--- a/Assets/Scripts/Status/StatusAffectable.cs
+++ b/Assets/Scripts/Status/StatusAffectable.cs
@@ -46,7 +46,7 @@ public class StatusAffectable : NetworkBehaviour
 
     private void FixedUpdate()
     {
-        foreach (Status status in _statuses)
+        foreach (Status status in new List<Status>(_statuses))
         {
             status.OnStatusFixedUpdate(gameObject);
         }
@@ -103,5 +103,10 @@ public class StatusAffectable : NetworkBehaviour
     {
         _statusIds.Remove(statusId);
         _durations.Remove(statusId);
+    }
+
+    public bool HasStatus(Status status)
+    {
+        return _statusIds.Contains((int) status);
     }
 }


### PR DESCRIPTION
## Fire is now in the game
- Fire can purge the miasma in a sphere around its point of origin. 
- Fire sets players and objects on-fire!  

## Potion visuals 
- Potion effects now change color based on their modifier components 
- Cube now has some crystal chunks sticking out of it. These have no gameplay effect and are entirely visual. 
- Puddle uses Miasma texture

## Other minor fixes 
- Player's collider is now set to be a **Capsule Collider** again. They can still stand on each though! They also struggle less with slopes. 
- Player now has a physics material
- Miasma avoids race conditions in the batch update, whatever that means idk lol
